### PR TITLE
fix: add .npmrc with strict-dep-builds=false

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+strict-dep-builds=false


### PR DESCRIPTION
## Summary
pnpm 10.7+ treats ignored postinstall scripts as hard errors by default, so every plugin's release CI now fails on transitive deps like `unrs-resolver@1.11.1` (pulled in via `eslint-config-etherpad` → `eslint-import-resolver-typescript`).

Set `strict-dep-builds=false` so unknown postinstalls emit a warning instead of failing the install. The build-script allowlist in the etherpad-lite core repo still controls which postinstalls actually run — this just stops an unknown one from exploding every plugin's CI when it lands in a transitive.

Generated with [Claude Code](https://claude.com/claude-code)