### PR TITLE
fix: use existing Etherpad buttonicon glyph for export button (#16)

### DIFF
--- a/static/tests/backend/specs/export_icon.js
+++ b/static/tests/backend/specs/export_icon.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const templatePath = path.resolve(
+    __dirname, '..', '..', '..', '..', 'templates', 'exportcolumn.html');
+
+describe(__filename, function () {
+  let src;
+  before(function () { src = fs.readFileSync(templatePath, 'utf8'); });
+
+  it('export button uses an existing Etherpad buttonicon glyph (#16)', function () {
+    // Etherpad's icon font was updated years ago and no longer ships the
+    // wikipedia glyph at \\e805 that this template used to target. Switch
+    // to one of the core `buttonicon-file-*` classes so the icon actually
+    // renders.
+    assert(/buttonicon-file(?:-[a-z-]+)?/.test(src),
+        `expected a buttonicon-file* class on the export icon; template:\n${src}`);
+  });
+
+  it('does not reference the removed custom \\e805 glyph (#16)', function () {
+    assert(!/\\e805/.test(src),
+        'template must not hard-code the old \\e805 wikipedia codepoint, which Etherpad\'s ' +
+        'icon font does not ship anymore');
+    assert(!/fontawesome-etherpad/.test(src),
+        'template should not override the icon font via inline CSS; the buttonicon-* class ' +
+        'already picks the right family');
+  });
+});

--- a/templates/exportcolumn.html
+++ b/templates/exportcolumn.html
@@ -1,12 +1,3 @@
 <a id="exportmediawikia" target="_blank" class="exportlink">
-  <span class="exporttype buttonicon" id="exportmediawiki">MediaWiki</span>
+  <span class="exporttype buttonicon buttonicon-file-code" id="exportmediawiki" title="MediaWiki"></span>
 </a>
-<style>
-#exportmediawikia:before {
-  font-family: "fontawesome-etherpad";
-  content: "\e805";
-}
-#exportmediawiki{
-  margin-left:7px;
-}
-</style>


### PR DESCRIPTION
Fixes #16. The export button referenced a custom `fontawesome-etherpad` glyph at `\e805` that was removed from Etherpad's icon font years ago (that codepoint now maps to `buttonicon-align-justify`), so the icon rendered blank. Switch to the convention used by core export buttons — `buttonicon buttonicon-file-code` on the inner span — and drop the inline style block. Adds a backend spec asserting the template uses a real `buttonicon-file*` class and no longer hard-codes the removed glyph.