### PR TITLE
fix: export superscript / subscript to MediaWiki (#14)

### DIFF
--- a/exportMediaWiki.js
+++ b/exportMediaWiki.js
@@ -20,8 +20,9 @@ const getMediaWikiFromAtext = (pad, atext) => {
   const textLines = atext.text.slice(0, -1).split('\n');
   const attribLines = Changeset.splitAttributionLines(atext.attribs, atext.text);
 
-  const tags = ['==', '===', '\'\'\'', '\'\'', 'u>', 's>'];
-  const props = ['heading1', 'heading2', 'bold', 'italic', 'underline', 'strikethrough'];
+  const tags = ['==', '===', '\'\'\'', '\'\'', 'u>', 's>', 'sup>', 'sub>'];
+  const props = ['heading1', 'heading2', 'bold', 'italic', 'underline', 'strikethrough',
+    'superscript', 'subscript'];
   const anumMap = {};
 
   props.forEach((propName, i) => {

--- a/static/tests/backend/specs/sup_sub.js
+++ b/static/tests/backend/specs/sup_sub.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const exporterPath = path.resolve(
+    __dirname, '..', '..', '..', '..', 'exportMediaWiki.js');
+
+describe(__filename, function () {
+  let src;
+  before(function () { src = fs.readFileSync(exporterPath, 'utf8'); });
+
+  it('MediaWiki exporter maps superscript/subscript attributes to <sup>/<sub> (#14)',
+      function () {
+        // Ensure the props array includes superscript/subscript and the
+        // tags array has the corresponding `sup>` / `sub>` markers. The
+        // `>`-suffixed tags are emitted wrapped in `<`/`</` by the
+        // existing emitOpenTag/emitCloseTag helpers.
+        const tagsMatch = src.match(/const\s+tags\s*=\s*\[([^\]]+)\]/);
+        const propsMatch = src.match(/const\s+props\s*=\s*\[([\s\S]*?)\]/);
+        assert(tagsMatch && propsMatch, 'expected tags/props arrays in exportMediaWiki.js');
+        const tags = tagsMatch[1];
+        const props = propsMatch[1];
+        for (const [tag, prop] of [["'sup>'", "'superscript'"], ["'sub>'", "'subscript'"]]) {
+          assert(tags.includes(tag),
+              `tags array should include ${tag} so <sup>/<sub> markers are emitted`);
+          assert(props.includes(prop),
+              `props array should include ${prop} so the attribute maps to the ${tag} tag`);
+        }
+      });
+});


### PR DESCRIPTION
Addresses part of #14. `superscript` and `subscript` line attributes (from the in-pad sup/sub buttons) were dropped by `exportMediaWiki.js`. Since the existing `emitOpenTag`/`emitCloseTag` helpers already support a `tag>` marker, adding `superscript`/`subscript` → `sup>`/`sub>` to the tags/props arrays is enough to emit `<sup>..</sup>` and `<sub>..</sub>` on export. The other items from #14 (code blocks, coloured text, indentation, heading levels) need larger changes and will be addressed separately. Backend spec asserts both attributes are now mapped.