### PR TITLE
feat: migrate to ep_plugin_helpers padToggle for User + Pad Wide settings

### DIFF
--- a/ep.json
+++ b/ep.json
@@ -3,15 +3,19 @@
     {
       "name": "mediawiki",
       "hooks":{
-        "getLineHTMLForExport": "ep_mediawiki/export",
-        "expressCreateServer": "ep_mediawiki/express",
+        "getLineHTMLForExport"  : "ep_mediawiki/export",
+        "expressCreateServer"   : "ep_mediawiki/express",
+        "loadSettings"          : "ep_mediawiki/index",
+        "clientVars"            : "ep_mediawiki/index",
         "eejsBlock_exportColumn": "ep_mediawiki/index",
-        "eejsBlock_scripts": "ep_mediawiki/index",
-        "eejsBlock_mySettings": "ep_mediawiki/index"
+        "eejsBlock_scripts"     : "ep_mediawiki/index",
+        "eejsBlock_mySettings"  : "ep_mediawiki/index",
+        "eejsBlock_padSettings" : "ep_mediawiki/index"
       },
       "client_hooks": {
-        "aceEditorCSS": "ep_mediawiki/static/js/mediawiki",
-        "postAceInit": "ep_mediawiki/static/js/mediawiki"
+        "aceEditorCSS"                       : "ep_mediawiki/static/js/mediawiki",
+        "postAceInit"                        : "ep_mediawiki/static/js/mediawiki",
+        "handleClientMessage_CLIENT_MESSAGE" : "ep_mediawiki/static/js/mediawiki"
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -1,7 +1,22 @@
 'use strict';
 
 const eejs = require('ep_etherpad-lite/node/eejs');
-const settings = require('ep_etherpad-lite/node/utils/Settings');
+const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
+
+// Parallel User Settings + Pad Wide Settings checkboxes for the MediaWiki
+// editor styling. Helper owns the storage, broadcast, enforce, and i18n wiring.
+const mediawikiToggle = padToggle({
+  pluginName: 'ep_mediawiki',
+  settingId: 'mediawiki',
+  l10nId: 'ep_mediawiki.mediawiki',
+  defaultLabel: 'Show MediaWiki',
+  defaultEnabled: false,
+});
+
+exports.loadSettings = mediawikiToggle.loadSettings;
+exports.clientVars = mediawikiToggle.clientVars;
+exports.eejsBlock_mySettings = mediawikiToggle.eejsBlock_mySettings;
+exports.eejsBlock_padSettings = mediawikiToggle.eejsBlock_padSettings;
 
 exports.eejsBlock_exportColumn = (hookName, args, cb) => {
   args.content += eejs.require('ep_mediawiki/templates/exportcolumn.html', {}, module);
@@ -10,23 +25,5 @@ exports.eejsBlock_exportColumn = (hookName, args, cb) => {
 
 exports.eejsBlock_scripts = (hookName, args, cb) => {
   args.content += eejs.require('ep_mediawiki/templates/scripts.html', {}, module);
-  cb();
-};
-
-exports.eejsBlock_styles = (hookName, args, cb) => {
-  args.content += eejs.require('ep_mediawiki/templates/styles.html', {}, module);
-  cb();
-};
-
-exports.eejsBlock_mySettings = (hookName, args, cb) => {
-  let checkedState;
-  if (!settings.ep_mediawiki_default) {
-    checkedState = 'unchecked';
-  } else if (settings.ep_mediawiki_default === true) {
-    checkedState = 'checked';
-  }
-  args.content += eejs.require('ep_mediawiki/templates/mediawiki_entry.ejs', {
-    checked: checkedState,
-  });
   cb();
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_mediawiki",
   "description": "Edit and Export as mediawiki in Etherpad",
-  "version": "11.0.20",
+  "version": "12.0.0",
   "author": {
     "name": "John McLear",
     "email": "john@mclear.co.uk",
@@ -15,6 +15,9 @@
   "funding": {
     "type": "individual",
     "url": "https://etherpad.org/"
+  },
+  "dependencies": {
+    "ep_plugin_helpers": "^0.3.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      ep_plugin_helpers:
+        specifier: ^0.3.0
+        version: 0.3.1
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -181,31 +185,37 @@ packages:
     resolution: {integrity: sha512-p+s/Wp8rf75Qqs2EPw4HC0xVLLW+/60MlVAsB7TYLoeg1e1CU/QCis36FxpziLS0ZY2+wXdTnPUxr+5kkThzwQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-arm64-musl@1.3.0':
     resolution: {integrity: sha512-cZEL9jmZ2kAN53MEk+fFCRJM8pRwOEboDn7sTLjZW+hL6a0/8JNfHP20n8+MBDrhyD34BSF4A6wPCj/LNhtOIQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-linux-ppc64-gnu@1.3.0':
     resolution: {integrity: sha512-IOeRhcMXTNlk2oApsOozYVcOHu4t1EKYKnTz4huzdPyKNPX0Y9C7X8/6rk4aR3Inb5s4oVMT9IVKdgNXLcpGAQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-s390x-gnu@1.3.0':
     resolution: {integrity: sha512-op54XrlEbhgVRCxzF1pHFcLamdOmHDapwrqJ9xYRB7ZjwP/zQCKzz/uAsSaAlyQmbSi/PXV7lwfca4xkv860/Q==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-gnu@1.3.0':
     resolution: {integrity: sha512-orbQF7sN02N/b9QF8Xp1RBO5YkfI+AYo9VZw0H2Gh4JYWSuiDHjOPEeFPDIRyWmXbQJuiVNSB+e1pZOjPPKIyg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/rspack-resolver-binding-linux-x64-musl@1.3.0':
     resolution: {integrity: sha512-kpjqjIAC9MfsjmlgmgeC8U9gZi6g/HTuCqpI7SBMjsa7/9MvBaQ6TJ7dtnsV/+DXvfJ2+L5teBBXG+XxfpvIFA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/rspack-resolver-binding-wasm32-wasi@1.3.0':
     resolution: {integrity: sha512-JAg0hY3kGsCPk7Jgh16yMTBZ6VEnoNR1DFZxiozjKwH+zSCfuDuM5S15gr50ofbwVw9drobIP2TTHdKZ15MJZQ==}
@@ -393,6 +403,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  ep_plugin_helpers@0.3.1:
+    resolution: {integrity: sha512-PHvLsJGJHQNLvP4R4k+D54f6JasD/uv9T4S0UaLHePjQBy0INpiS8iFXLeAY60EbgeznhMJLgE2DVy+32bZTLQ==}
+    engines: {node: '>=18.0.0'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1666,6 +1680,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.2
+
+  ep_plugin_helpers@0.3.1: {}
 
   es-abstract@1.24.2:
     dependencies:

--- a/static/js/mediawiki.js
+++ b/static/js/mediawiki.js
@@ -1,9 +1,29 @@
 'use strict';
 
+// Sub-path import keeps the client bundle clean. Importing the top-level
+// `ep_plugin_helpers` index pulls in every helper's getters; `settings` and
+// `toggle` reach server-only modules (eejs, Settings) which esbuild can't
+// resolve for the browser.
+const {padToggle} = require('ep_plugin_helpers/pad-toggle');
+
+// Same config as the server-side instance — must agree on pluginName,
+// settingId, l10nId, and defaultLabel for the checkbox ids and clientVars
+// lookup to line up.
+const mediawikiToggle = padToggle({
+  pluginName: 'ep_mediawiki',
+  settingId: 'mediawiki',
+  l10nId: 'ep_mediawiki.mediawiki',
+  defaultLabel: 'Show MediaWiki',
+  defaultEnabled: false,
+});
+
+// Re-export so the helper sees pad-wide broadcasts and refreshes our state
+// when another user toggles the pad-wide checkbox.
+exports.handleClientMessage_CLIENT_MESSAGE = mediawikiToggle.handleClientMessage_CLIENT_MESSAGE;
+
 exports.postAceInit = (hook, context) => {
   const mediawiki = {
     enable: () => {
-      // add css class mediawiki
       $('iframe[name="ace_outer"]').contents().find('iframe')
           .contents().find('#innerdocbody').addClass('mediawiki');
     },
@@ -13,28 +33,18 @@ exports.postAceInit = (hook, context) => {
     },
   };
 
-  /* init */
-  if ($('#options-mediawiki').is(':checked')) {
-    mediawiki.enable();
-  } else {
-    mediawiki.disable();
-  }
-  /* on click */
-  $('#options-mediawiki').on('click', () => {
-    if ($('#options-mediawiki').is(':checked')) {
-      mediawiki.enable();
-    } else {
-      mediawiki.disable();
-    }
+  mediawikiToggle.init({
+    onChange: (enabled) => { enabled ? mediawiki.enable() : mediawiki.disable(); },
   });
-  /* Param initiator */
-  // if the url param is set
-  const urlContainsMediawikiTrue = (getParam('mediawiki') === 'true');
-  if (urlContainsMediawikiTrue) {
-    $('#options-mediawiki').attr('checked', 'checked');
+
+  // ?mediawiki=true / ?mediawiki=false URL parameter still overrides the
+  // resolved setting, matching the pre-migration behavior.
+  const param = getParam('mediawiki');
+  if (param === 'true') {
+    $('#options-mediawiki').prop('checked', true);
     mediawiki.enable();
-  } else if (getParam('mediawiki') === 'false') {
-    $('#options-mediawiki').attr('checked', false);
+  } else if (param === 'false') {
+    $('#options-mediawiki').prop('checked', false);
     mediawiki.disable();
   }
 };
@@ -46,10 +56,9 @@ const getParam = (sname) => {
   let params = location.search.substr(location.search.indexOf('?') + 1);
   let sval = '';
   params = params.split('&');
-  // split param and value into individual pieces
   for (let i = 0; i < params.length; i++) {
     const temp = params[i].split('=');
-    if ([temp[0]] === sname) { sval = temp[1]; }
+    if (temp[0] === sname) { sval = temp[1]; }
   }
   return sval;
 };

--- a/templates/mediawiki_entry.ejs
+++ b/templates/mediawiki_entry.ejs
@@ -1,4 +1,0 @@
-<p>
-  <input type="checkbox" id="options-mediawiki" <%= checked %>></input> 
-  <label for="options-mediawiki">Show MediaWiki</label>
-</p>


### PR DESCRIPTION
## Summary

- Replace the hand-rolled User Settings checkbox + manual click wiring with `padToggle` from [ep_plugin_helpers ^0.3.0](https://www.npmjs.com/package/ep_plugin_helpers). Users now get a parallel checkbox in **Pad Wide Settings** that broadcasts via Etherpad's existing `padoptions` rail to every connected client and is honored by `enforceSettings`, matching how native toggles (sticky chat, line numbers) work.
- Drop the obsolete `mediawiki_entry.ejs` template and the misnamed top-level `settings.ep_mediawiki_default` flag (helper reads `settings.ep_mediawiki.defaultEnabled`).
- Add a real i18n key (`ep_mediawiki.mediawiki`) — the pre-migration template had no `data-l10n-id`, just hardcoded English. `defaultLabel: 'Show MediaWiki'` keeps screen readers covered before html10n loads.
- Fix latent URL-param bug: `[temp[0]] === sname` compared an array reference to a string and always evaluated false, so `?mediawiki=true|false` never actually fired before this PR.
- Bumped to **12.0.0** to flag the new `ep_plugin_helpers` peer requirement and the i18n key addition.

## Compatibility

Pad-wide column degrades to a no-op on Etherpad cores without the `ep_*` padOptions passthrough patch (< 2.7.4); the user-side cookie toggle is unaffected — plugin keeps working everywhere.

## Test plan

- [x] Backend mocha specs (`exportHTML.js`, `export_icon.js`, `sup_sub.js`) — 4 passing
- [x] Playwright frontend smoke spec — 1 passing
- [x] Lint clean for the files touched (`index.js`, `static/js/mediawiki.js`); only pre-existing warnings remain in unrelated files
- [ ] Reviewer: confirm pad-wide checkbox appears in Pad Wide Settings panel and broadcasts to other connected clients
- [ ] Reviewer: confirm User Settings checkbox still toggles the `.mediawiki` class on `#innerdocbody`
- [ ] Reviewer: confirm `?mediawiki=true` / `?mediawiki=false` URL override still wins

DO NOT MERGE — coordinated with the rest of the padToggle migration sweep.

Reference migration: ep_table_of_contents `feat/migrate-to-pad-toggle`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code