### PR TITLE
refactor: adopt template helper for 2 simple eejsBlock_* hook(s)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs');
+const {template} = require('ep_plugin_helpers');
+
 const {padToggle} = require('ep_plugin_helpers/pad-toggle-server');
 
 // Parallel User Settings + Pad Wide Settings checkboxes for the MediaWiki
@@ -18,12 +19,8 @@ exports.clientVars = mediawikiToggle.clientVars;
 exports.eejsBlock_mySettings = mediawikiToggle.eejsBlock_mySettings;
 exports.eejsBlock_padSettings = mediawikiToggle.eejsBlock_padSettings;
 
-exports.eejsBlock_exportColumn = (hookName, args, cb) => {
-  args.content += eejs.require('ep_mediawiki/templates/exportcolumn.html', {}, module);
-  cb();
-};
+exports.eejsBlock_exportColumn =
+    template('ep_mediawiki/templates/exportcolumn.html');
 
-exports.eejsBlock_scripts = (hookName, args, cb) => {
-  args.content += eejs.require('ep_mediawiki/templates/scripts.html', {}, module);
-  cb();
-};
+exports.eejsBlock_scripts =
+    template('ep_mediawiki/templates/scripts.html');


### PR DESCRIPTION
## Summary

Adopts `template()` from `ep_plugin_helpers` for 2 `eejsBlock_*` hook(s) of shape:

```js
exports.eejsBlock_X = (hookName, args, cb) => {
  args.content += eejs.require('plugin/template.ejs'[, {}[, module]]);
  cb();
};
```

Replaced with `exports.eejsBlock_X = template('plugin/template.ejs');`. Same runtime behavior.

Part of Phase 4 of the modernization campaign. Wave 1: ether/ep_themes#103 + 6 small plugins. Wave 2 picks up hooks with explicit empty-vars / module argument that wave 1's stricter regex skipped.