### PR TITLE
docs: clarify ep_plugin_helpers helper name in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ ep_mediawiki/
 
 ## Helpers used
 
-* `pad-toggle` from `ep_plugin_helpers`
-* `pad-toggle-server` from `ep_plugin_helpers`
+* `padToggle` (client sub-path) from `ep_plugin_helpers`
+* `padToggle` (server) from `ep_plugin_helpers`
 
 
 ## Helpers NOT used


### PR DESCRIPTION
Cosmetic AGENTS.md fix. The auto-generated "Helpers used" section listed `pad-toggle` / `pad-toggle-server` as if they were separate helpers — they're sub-paths of the canonical `padToggle`. This PR re-labels them so a future agent can grep the codebase by helper name.